### PR TITLE
PolyQuanta: improve randomization timing precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Core test build is Rack-SDK optional**: `make core_tests` now proxies to a standalone `tests/Makefile`, so headless test builds succeed even when `plugin.mk` is unavailable (Codex/CI containers).
 
 ### Fixed
+- **PolyQuanta sync randomization precision**: Promoted the clock/multiplication timekeeping to double precision so long-running subdivisions keep firing on schedule.
 - **PolyQuanta rounding nudges honor tuning**: Directional/Ceil/Floor rounding now derives the nudge size from the active
   tuning step instead of assuming 12-EDO semitones, keeping non-12 scales aligned.
 - **Quantizer limit bounding respects scale masks**: When `boundToLimit` clamps


### PR DESCRIPTION
## Summary
- promote PolyQuanta's sync randomization timers to double precision to prevent long-run drift
- refresh the reset and process scheduling logic so dt accumulation and multiplication pulses use the new double values
- document the timing precision fix in the changelog

## Testing
- make quick *(fails: Rack SDK plugin.mk missing in container, build recurses indefinitely)*
- make -C tests
- ./build/core_tests


------
https://chatgpt.com/codex/tasks/task_e_68cc72e3edf88329965fa3a39e758fbf